### PR TITLE
LC - Fix `Document#flatten_paragraph` bug related to empty text nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.2
+
+### Improvements and bugfixes
+
+* Fix a bug related to a bad empty text nodes handling approach inside
+  `Document#flatten_paragraph` logic.
+
 ## 2.0.1
 
 ### Improvements and bugfixes

--- a/lib/lm_docstache/document.rb
+++ b/lib/lm_docstache/document.rb
@@ -135,10 +135,12 @@ module LMDocstache
         previous_run_node = run_nodes.last
         previous_style_node = previous_run_node.at_css('w|rPr')
         previous_style_html = previous_style_node ? previous_style_node.inner_html : ''
+        previous_text_node = previous_run_node.at_css('w|t')
+        current_text_node = run_node.at_css('w|t')
 
         next if style_html != previous_style_html
+        next if current_text_node.nil? || previous_text_node.nil?
 
-        previous_text_node = previous_run_node.at_css('w|t')
         previous_text_node.content = previous_text_node.text + run_node.text
         run_node.unlink
       end

--- a/lib/lm_docstache/version.rb
+++ b/lib/lm_docstache/version.rb
@@ -1,3 +1,3 @@
 module LMDocstache
-  VERSION = "2.0.1"
+  VERSION = "2.0.2"
 end


### PR DESCRIPTION
## Context

This PR fixes a bug related to text nodes merging in `Document#flatten_paragraph` (called in `Document#fix_errors`), which was doing a faulty job when handling with `w:r` nodes that didn't have `w:t` in it.