### PR TITLE
Replaced Renderer hide_custom_tags options to be a  Hash instead of Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 2.1.2
+## 3.0.0
+
+## Breaking Changes
+* Replaced Renderer `hide_custom_tags` options to be a `Hash` instead of `Array`.
+  There are are edge cases which we want to replace the content on hide custom tags.
+  All documentations can be followed on `Renderer` and `HideCustomTag` classes.
 
 ### Bugfix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   There are are edge cases which we want to replace the content on hide custom tags.
   All documentations can be followed on `Renderer` and `HideCustomTag` classes.
 
+## 2.1.2
+
 ### Bugfix
 
 * Giving a document there is no *rPr* tag we should add new *rPr* tag before 

--- a/lib/lm_docstache/renderer.rb
+++ b/lib/lm_docstache/renderer.rb
@@ -6,7 +6,8 @@ module LMDocstache
 
     def initialize(xml, data, options = {})
       @content = xml
-      @parser = Parser.new(xml, data, options.slice(:special_variable_replacements, :hide_custom_tags))
+      option_types = [:special_variable_replacements, :hide_custom_tags]
+      @parser = Parser.new(xml, data, options.slice(*option_types))
     end
 
     def render

--- a/lib/lm_docstache/version.rb
+++ b/lib/lm_docstache/version.rb
@@ -1,3 +1,3 @@
 module LMDocstache
-  VERSION = "2.1.2"
+  VERSION = "3.0.0"
 end

--- a/spec/hide_custom_tags_spec.rb
+++ b/spec/hide_custom_tags_spec.rb
@@ -58,7 +58,7 @@ describe LMDocstache::HideCustomTags do
         end
       end
     end
-    context 'giving a document without rpr and blcok tags on the left' do
+    context 'giving a document without rpr and block tags on the left' do
       let(:input_file) { "#{base_path}/docx-no-rpr.docx" }
 
       it 'expect to have a white color on all hide custom tags matching and have first child node equal rPr tag' do

--- a/spec/hide_custom_tags_spec.rb
+++ b/spec/hide_custom_tags_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe LMDocstache::HideCustomTags do
-
   context '#example' do
     let(:output_dir) { "#{base_path}/tmp/" }
     let(:output_file) { File.new("#{output_dir}/BlankTestOutput.docx", 'w') }
@@ -16,10 +15,18 @@ describe LMDocstache::HideCustomTags do
     end
 
     let(:base_path) { SPEC_BASE_PATH.join('example_input') }
-    let(:document) { LMDocstache::Document.new(input_file).instance_variable_get(:@document) }
-    let(:regexp_tag) { /{{(?:sig|sigfirm|date|check|text|initial)\|(?:req|noreq)\|.+?}}/ }
+    let(:document) {
+      doc = LMDocstache::Document.new(input_file)
+      doc.fix_errors
+      doc.instance_variable_get(:@document)
+    }
+    let(:regexp_tag) { /(?:sig|sigfirm|date|text|initial)\|(?:req|noreq)\|.+?/ }
+    let(:regexp_for_replacement) { /(?:check)\|(?:req|noreq)\|.+?/ }
     let(:hide_custom_tags) {
-      LMDocstache::HideCustomTags.new(document: document, hide_custom_tags: [ regexp_tag ])
+      LMDocstache::HideCustomTags.new(document: document, hide_custom_tags: {
+        /#{regexp_tag}/ => false,
+        /#{regexp_for_replacement}/ => 'replaced_content'
+      })
     }
 
     context "giving a document with blue background" do
@@ -30,10 +37,9 @@ describe LMDocstache::HideCustomTags do
         d = hide_custom_tags.document
         run_nodes = d.css('w|p w|r')
         while run_node = run_nodes.shift
-          if run_node.text =~ regexp_tag
-            expect(run_node.at_css('w|rPr w|color').first[1]).to eq('4472C4')
-            expect(run_node.children.first.name).to eq('rPr')
-          end
+          next unless run_node.text =~ regexp_tag
+          expect(run_node.at_css('w|rPr w|color').first[1]).to eq('4472C4')
+          expect(run_node.children.first.name).to eq('rPr')
         end
       end
     end
@@ -46,14 +52,13 @@ describe LMDocstache::HideCustomTags do
         d = hide_custom_tags.document
         run_nodes = d.css('w|p w|r')
         while run_node = run_nodes.shift
-          if run_node.text =~ regexp_tag
-            expect(run_node.at_css('w|rPr w|color').first[1]).to eq('FFFFFF')
-            expect(run_node.children.first.name).to eq('rPr')
-          end
+          next unless run_node.text =~ regexp_tag
+          expect(run_node.at_css('w|rPr w|color').first[1]).to eq('FFFFFF')
+          expect(run_node.children.first.name).to eq('rPr')
         end
       end
     end
-    context 'giving a document without rpr' do
+    context 'giving a document without rpr and blcok tags on the left' do
       let(:input_file) { "#{base_path}/docx-no-rpr.docx" }
 
       it 'expect to have a white color on all hide custom tags matching and have first child node equal rPr tag' do
@@ -61,11 +66,23 @@ describe LMDocstache::HideCustomTags do
         d = hide_custom_tags.document
         run_nodes = d.css('w|p w|r')
         while run_node = run_nodes.shift
-          if run_node.text =~ regexp_tag
-            expect(run_node.at_css('w|rPr w|color').first[1]).to eq('FFFFFF')
-            expect(run_node.children.first.name).to eq('rPr')
-          end
+          next unless run_node.text =~ regexp_tag
+          expect(run_node.at_css('w|rPr w|color').first[1]).to eq('FFFFFF')
+          expect(run_node.children.first.name).to eq('rPr')
         end
+      end
+      it 'expect to have a white color on all replacement tags and content following replacement' do
+        hide_custom_tags.hide_custom_tags!
+        d = hide_custom_tags.document
+        run_nodes = d.css('w|p w|r')
+        total_replacement = 0
+        while run_node = run_nodes.shift
+          next unless run_node.text =~ /replaced_content/
+          total_replacement+=1
+          expect(run_node.at_css('w|rPr w|color').first[1]).to eq('FFFFFF')
+          expect(run_node.children.first.name).to eq('rPr')
+        end
+        expect(total_replacement).to eq(2)
       end
     end
   end


### PR DESCRIPTION
Replaced Renderer `hide_custom_tags` options to be a `Hash` instead of `Array`.
  There are are edge cases which we want to replace the content on hide custom tags.
  All documentations can be followed on `Renderer` and `HideCustomTag` classes.