### PR TITLE
Fix replacement nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
+## 3.0.3
+
+### Bugfix
+
+* Hide custom tags arguments was pushing blocks tags to end of paragraph. There are cases this approach
+ doesn't work. I changed to be an ordered replacement when we match hide tags.
+* Avoid to merge Tab tags on fix errors methods. This was causing unexpected document changes.  
+
 ## 3.0.2
 
 ### Bugfix
 
 * Fix replacing tags related to hidden custom tags regexp formats. E.g. tab characters.
-
 
 ## 3.0.1
 

--- a/lib/lm_docstache/document.rb
+++ b/lib/lm_docstache/document.rb
@@ -138,6 +138,10 @@ module LMDocstache
         previous_text_node = previous_run_node.at_css('w|t')
         current_text_node = run_node.at_css('w|t')
 
+        # avoid to merge blocks with tabs
+        next if run_node.at_css('w|tab')
+        next if previous_run_node.at_css('w|tab')
+
         next if style_html != previous_style_html
         next if current_text_node.nil? || previous_text_node.nil?
 

--- a/lib/lm_docstache/hide_custom_tags.rb
+++ b/lib/lm_docstache/hide_custom_tags.rb
@@ -30,15 +30,15 @@ module LMDocstache
           while run_node = run_nodes.shift
             next unless run_node.at_css('w|t')
             next unless run_node.text =~ full_pattern
-            remainder_run_node = run_node.clone
-            run_node.unlink
-            tag_contents = split_tag_content(remainder_run_node.text, full_pattern)
+            tag_contents = split_tag_content(run_node.text, full_pattern)
+            replacement_nodes = []
             tag_contents[:content_list].each_with_index do |content, idx|
+              remainder_run_node = run_node.clone
               replace_content(remainder_run_node, content)
               matched_tag = tag_contents[:matched_tags][idx]
-              nodes_list = [remainder_run_node]
+              replacement_nodes << remainder_run_node
               if matched_tag
-                run_node_with_match = remainder_run_node.dup
+                run_node_with_match = run_node.clone
                 replace_style(run_node_with_match)
                 matched_content = matched_tag
                 if value
@@ -47,11 +47,11 @@ module LMDocstache
                        value.to_s
                 end
                 replace_content(run_node_with_match, matched_content)
-                nodes_list << run_node_with_match
+                replacement_nodes << run_node_with_match
               end
-              paragraph << Nokogiri::XML::NodeSet.new(document, nodes_list)
-              remainder_run_node = remainder_run_node.clone
             end
+            run_node.add_next_sibling(Nokogiri::XML::NodeSet.new(document, replacement_nodes))
+            run_node.unlink
           end
         end
       end

--- a/lib/lm_docstache/version.rb
+++ b/lib/lm_docstache/version.rb
@@ -1,3 +1,3 @@
 module LMDocstache
-  VERSION = "3.0.2"
+  VERSION = "3.0.3"
 end


### PR DESCRIPTION
* Hide custom tags arguments was pushing blocks tags to end of paragraph. There are cases this approach
 doesn't work. I changed to be an ordered replacement when we match hide tags.
* Avoid to merge Tab tags on fix errors methods. This was causing unexpected document changes.  
