### PR TITLE
LC - Bug fix: prevent `nil` being passed to `broken_tags.delete_at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.6
+
+#### Bug fixes
+
+* Fix bug on `LMDocstache::Docstache#unusable_tags` method, where `nil` could be
+  passed to `broken_tags.deleted_at` call.
+
 ## 3.0.5
 
 #### Bug fixes and improvements

--- a/lib/lm_docstache/document.rb
+++ b/lib/lm_docstache/document.rb
@@ -65,7 +65,9 @@ module LMDocstache
       conditional_start_tags = text_nodes_containing_only_starting_conditionals.map(&:text)
 
       usable_tags.reduce(tags) do |broken_tags, usable_tag|
-        broken_tags.delete_at(broken_tags.index(usable_tag)) && broken_tags
+        next broken_tags unless index = broken_tags.index(usable_tag)
+
+        broken_tags.delete_at(index) && broken_tags
       end.reject do |broken_tag|
         operator = broken_tag.is_a?(Regexp) ? :=~ : :==
         start_tags_index = conditional_start_tags.find_index do |start_tag|

--- a/lib/lm_docstache/version.rb
+++ b/lib/lm_docstache/version.rb
@@ -1,3 +1,3 @@
 module LMDocstache
-  VERSION = "3.0.5"
+  VERSION = "3.0.6"
 end


### PR DESCRIPTION
This is just a minor bug fix for `LMDocstache::Document#unusable_tags` method that got improved in previous version release but also got this bug that is being fixed with this PR.