### PR TITLE
LC - Fix `usable_tags` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.0.8
+
+#### Bug fixes
+
+* Fix a bug on `usable_tags` method, so it now properly and expectedly
+  includes conditional tag names that have its opening tag markup as the sole
+  content of paragraphs (which represents conditional blocks where both
+  opening and closing tags are in separate parapraghs sorrounding one or more
+  paragraphs as its conditional block content).
+
 ## 3.0.7
 
 #### Bug fixes

--- a/lib/lm_docstache/document.rb
+++ b/lib/lm_docstache/document.rb
@@ -125,8 +125,8 @@ module LMDocstache
 
     def text_nodes_containing_only_starting_conditionals
       @documents.values.flat_map do |document|
-        document.css('w|t').select do |paragraph|
-          paragraph.text =~ WHOLE_BLOCK_START_REGEX
+        document.css('w|t').select do |text_node|
+          text_node.text =~ WHOLE_BLOCK_START_REGEX
         end
       end
     end

--- a/lib/lm_docstache/document.rb
+++ b/lib/lm_docstache/document.rb
@@ -63,20 +63,10 @@ module LMDocstache
     end
 
     def unusable_tags
-      conditional_start_tags = text_nodes_containing_only_starting_conditionals.map(&:text)
-
       usable_tags.reduce(tags) do |broken_tags, usable_tag|
         next broken_tags unless index = broken_tags.index(usable_tag)
 
         broken_tags.delete_at(index) && broken_tags
-      end.reject do |broken_tag|
-        operator = broken_tag.is_a?(Regexp) ? :=~ : :==
-        start_tags_index = conditional_start_tags.find_index do |start_tag|
-          broken_tag.send(operator, start_tag)
-        end
-
-        conditional_start_tags.delete_at(start_tags_index) if start_tags_index
-        !!start_tags_index
       end
     end
 
@@ -122,14 +112,6 @@ module LMDocstache
         .gsub('\\}', '}')
         .gsub('\\^', '^')
         .gsub('\\ ', ' ')
-    end
-
-    def text_nodes_containing_only_starting_conditionals
-      @documents.values.flat_map do |document|
-        document.css('w|t').select do |text_node|
-          text_node.text =~ WHOLE_BLOCK_START_REGEX
-        end
-      end
     end
 
     def extract_tag_names(text, tag_type = :variable)

--- a/lib/lm_docstache/document.rb
+++ b/lib/lm_docstache/document.rb
@@ -38,7 +38,7 @@ module LMDocstache
     def tags
       @documents.values.flat_map do |document|
         document_text = document.text
-        extract_tag_names(document_text) + extract_tag_names(document_text, true)
+        extract_tag_names(document_text) + extract_tag_names(document_text, :full_block)
       end
     end
 
@@ -47,7 +47,8 @@ module LMDocstache
         document.css('w|t').reduce(tags) do |document_tags, text_node|
           text = text_node.text
           document_tags.push(*extract_tag_names(text))
-          document_tags.push(*extract_tag_names(text, true))
+          document_tags.push(*extract_tag_names(text, :start_block))
+          document_tags.push(*extract_tag_names(text, :full_block))
         end
       end
     end

--- a/lib/lm_docstache/version.rb
+++ b/lib/lm_docstache/version.rb
@@ -1,3 +1,3 @@
 module LMDocstache
-  VERSION = "3.0.7"
+  VERSION = "3.0.8"
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -70,7 +70,9 @@ describe 'integration test', integration: true do
     end
 
     it 'has the expected amount of usable tags' do
-      expect(document.usable_tags.count).to eq(28)
+      expect { document.fix_errors }.to change {
+        document.usable_tags.count
+      }.from(29).to(34)
     end
 
     it 'has the expected amount of usable roles tags' do


### PR DESCRIPTION
We currently have a bug/flaw in `LMDocstache::Document#usable_tags` method, where paragraph nodes whose content is solely an opening tag of a conditonal block weren't being considered. This PR fixes this flaw.