### PR TITLE
LC - Fix bug introduced in the previous version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.0.10
+
+#### Bug fixes
+
+* Only try to access and set text node's "xml:space" attribute if the text node
+  exists (in `LMDocstache::Document#flatten_text_blocks` private method).
+
 ## 3.0.9
 
 #### Bug fixes

--- a/lib/lm_docstache/document.rb
+++ b/lib/lm_docstache/document.rb
@@ -174,11 +174,11 @@ module LMDocstache
         previous_style_html = previous_style_node ? previous_style_node.inner_html : ''
         previous_text_node = previous_node.at_css('w|t')
         current_text_node = node.at_css('w|t')
-        whitespace_attr = current_text_node['xml:space']
 
         next if style_html != previous_style_html
         next if current_text_node.nil? || previous_text_node.nil?
 
+        whitespace_attr = current_text_node['xml:space']
         previous_text_node['xml:space'] = whitespace_attr if whitespace_attr
         previous_text_node.content = previous_text_node.text + current_text_node.text
 

--- a/lib/lm_docstache/version.rb
+++ b/lib/lm_docstache/version.rb
@@ -1,3 +1,3 @@
 module LMDocstache
-  VERSION = "3.0.9"
+  VERSION = "3.0.10"
 end


### PR DESCRIPTION
We were trying to access and set the `xml:space` attribute on the text node without checking if the text node exists before anything. This small patch fixes that.